### PR TITLE
<1> Fix TypeError when writing html to outputfile <2> Output original exception

### DIFF
--- a/htmlmerge
+++ b/htmlmerge
@@ -635,9 +635,10 @@ else:
 
     try:
         with open (outfile,'w') as f:
-            f.write ( all_html )
-    except:
-        error ("Failed to save \"" + outfile + "\" ! Do we have permission?")
+            f.write ( all_html.decode('utf-8') )
+    except Exception as e:
+        error ("Failed to save \"" + outfile + "\" ! Do we have permission? (Original error below)")
+        error (e)
         sys.exit(1)
     # end try
 # end if


### PR DESCRIPTION
1. TypeError: write() argument must be str, not bytes
Thrown because of encoding on Windows with python 3.8.x
2. Write exception to console instead of writing your own