### PR TITLE
Output exception when file.read() fails to help with debugging.

### DIFF
--- a/htmlmerge
+++ b/htmlmerge
@@ -380,8 +380,9 @@ else:
     try:
         with open (infile,'r') as f:
             indexHTML = f.read()
-    except:
+    except Exception as e:
         error ("Could not open \"" + infile + "\" !")
+        print(e)
         sys.exit(1)
     # end try
 # end if
@@ -418,8 +419,9 @@ if merge_js:
         try:
             with open (src_url,'r') as f:
                 all_scripts += f.read()
-        except:
+        except Exception as e:
             error ("Could not open \"" + src_url + "\" !")
+            print(e)
             sys.exit(1)
         # end try
 
@@ -496,8 +498,9 @@ if merge_css:
                 try:
                     with open (src_url,'r') as f:
                         all_css += f.read()
-                except:
+                except Exception as e:
                     error ("Could not open \"" + src_url + "\" !")
+                    print(e)
                     sys.exit(1)
                 # end try
 
@@ -541,8 +544,9 @@ if merge_css:
                         with open (src_url,'r') as f:
                             # insert loaded css at old @import index
                             all_css.insert (idx, f.read())
-                    except:
+                    except Exception as e:
                         error ("Could not open \"" + src_url + "\" !")
+                        print(e)
                         sys.exit(1)
                     # end try
                 # end if


### PR DESCRIPTION
To help with debugging, output the exception message below the generic "could not open".

![image](https://github.com/user-attachments/assets/789106da-833a-4efb-ac81-62b9f58c58c7)
